### PR TITLE
Adjust Search Queries

### DIFF
--- a/src/controllers/snippets.ts
+++ b/src/controllers/snippets.ts
@@ -259,10 +259,10 @@ export const searchSnippets = asyncWrapper(
     }
 
     const languageFilter = languages.length
-      ? { [Op.in]: languages }
+      ? { [Op.like]: languages }
       : { [Op.notIn]: languages };
 
-    const tagFilter = tags.length ? { [Op.in]: tags } : { [Op.notIn]: tags };
+    const tagFilter = tags.length ? { [Op.like]: tags } : { [Op.notIn]: tags };
 
     const snippets = await SnippetModel.findAll({
       where: {


### PR DESCRIPTION
Currently the Search for Languages and Tags is case sensitive. These adjustments make them case insensitive.